### PR TITLE
Fix commit "test actu maj"

### DIFF
--- a/shinyapp/www/actus/actus.yaml
+++ b/shinyapp/www/actus/actus.yaml
@@ -1,13 +1,13 @@
 ---
 - actu1:
     lien: https://datafoncier.cerema.fr/actualites/retour-sur-rendez-datafoncier-ndeg7-du-3-avril-2025
-    image: https://github.com/CEREMA/cartofriches/blob/c87db813453427d9009d05464493a8e2020f6af5/shinyapp/www/actus/news_webinairedatafoncier_2025.PNG?raw=true
+    image: https://raw.githubusercontent.com/CEREMA/cartofriches/refs/heads/main/shinyapp/www/actus/news_webinairedatafoncier_2025.PNG
     titre: Webinaire Datafoncier du 3 avril 2025
     width: 70%
     height: 250px
 - actu2:
     lien: https://artificialisation.developpement-durable.gouv.fr/actualites/webinaire-amenager-les-friches-avec-urbanvitaliz-et-cartofriches-replay
-    image: https://github.com/CEREMA/cartofriches/blob/c87db813453427d9009d05464493a8e2020f6af5/shinyapp/www/actus/news_webinaireCNFPT_2025.PNG?raw=true
+    image: https://raw.githubusercontent.com/CEREMA/cartofriches/refs/heads/main/shinyapp/www/actus/news_webinaireCNFPT_2025.PNG
     titre: Webinaire CNFPT/Intercommunalité de France du 11 mars 2025
     width: 70%
     height: 250px


### PR DESCRIPTION
### Présentation du bug sur le site de Cartofriche

Les dernières actualités publiés sur la page d’accueil de cartofriches montrent ici un echec de requête sur certaines images publiées.

![image](https://github.com/user-attachments/assets/23b237d7-9a09-45bc-a624-601d8ce980bf)


### Origine du bug
Ce bug est est introduit dans le commit [c87db813453427d9009d05464493a8e2020f6af5](https://github.com/CEREMA/cartofriches/commit/c87db813453427d9009d05464493a8e2020f6af5) le 06/05/2025 par M. Nicolas Pelé.

GitHub a une politique distincte pour servir le contenu de ses dépôts en fonction de son type et de son utilisation prévue.
Les pages web servies ici sont dynamiques et incluent des éléments d'interface utilisateur, des contrôles d'accès et diverses fonctionnalités interactives.
Pour des raisons de sécurité et de performance, GitHub ne sert pas directement le contenu brut des fichiers (comme les images) à travers cette interface. 
En effet, Les pages web de GitHub incluent des en-têtes de sécurité (comme Content-Security-Policy) qui empêchent les navigateurs d'interpréter le contenu brut des fichiers comme des images dans un contexte différent. 
 GitHub fournit un service distinct, https://raw.githubusercontent.com/, spécifiquement conçu pour servir le contenu brut des fichiers stockés dans les dépôts sans l'enrobage de l'interface web de GitHub. Ce domaine est optimisé pour servir des fichiers statiques bruts et ne nécessite pas d'authentification.
En résumé, la politique de GitHub est de séparer la présentation web de ses dépôts du service de contenu brut.

### Correctif
Le fichier descriptif actus.yaml exploitée pour la publication des actualitées sur la page d’accueil de cartofriches doit ainsi être actualisée.
[Une Pull Request corrective est soumise](https://github.com/CEREMA/cartofriches/commit/8fac3c1ad75640f7677a56191948803225fb3956). Ainsi, M. Nicolas Pelé pourra effectuer une revision et accepter directement ce correctif dans le dépôt de Cartofriches.