### PR TITLE
Fix commit "test actu maj" : Lien relatifs imposés par ShinyApp

### DIFF
--- a/shinyapp/www/actus/actus.yaml
+++ b/shinyapp/www/actus/actus.yaml
@@ -1,13 +1,13 @@
 ---
 - actu1:
     lien: https://datafoncier.cerema.fr/actualites/retour-sur-rendez-datafoncier-ndeg7-du-3-avril-2025
-    image: https://raw.githubusercontent.com/CEREMA/cartofriches/refs/heads/main/shinyapp/www/actus/news_webinairedatafoncier_2025.PNG
+    image: news_webinairedatafoncier_2025.PNG
     titre: Webinaire Datafoncier du 3 avril 2025
     width: 70%
     height: 250px
 - actu2:
     lien: https://artificialisation.developpement-durable.gouv.fr/actualites/webinaire-amenager-les-friches-avec-urbanvitaliz-et-cartofriches-replay
-    image: https://raw.githubusercontent.com/CEREMA/cartofriches/refs/heads/main/shinyapp/www/actus/news_webinaireCNFPT_2025.PNG
+    image: news_webinaireCNFPT_2025.PNG
     titre: Webinaire CNFPT/Intercommunalité de France du 11 mars 2025
     width: 70%
     height: 250px


### PR DESCRIPTION
Suite de la [PR6](https://github.com/CEREMA/cartofriches/pull/6), visiblement ShinyApp n'accepte que des liens relatifs.